### PR TITLE
Fixes bottomNavMenu margin

### DIFF
--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -139,6 +139,7 @@ class _HomePageState extends State<HomePage> {
         child: Scaffold(
           backgroundColor: Provider.of<ThemesNotifier>(context).currentThemeData.backgroundColor,
           body: SafeArea(
+            bottom: false,
             child: Stack(
               // Holds all the pages that sould be accessable within the bottom nav-menu
               children: [


### PR DESCRIPTION
This PR fixes the visual bug where the bottomNavMenu was placed above the bottom navigation bar on iPhones because of the `SafeArea` widget.
The bug was initially created in PR https://github.com/astarub/campus_app/pull/33 by putting the bottomNavMenu into the `Stack` widget instead of the `Scaffold` itself.