### PR TITLE
Add NDEF entitlement

### DIFF
--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -11,6 +11,7 @@
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
 		<string>TAG</string>
+		<string>NDEF</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Due to an error while publishing the app to the Appstore, the NDEF entitlement has to be added to the XCode project. 