### PR TITLE
what is this

### DIFF
--- a/lib/pages/rubsignin/widgets/signin_form.dart
+++ b/lib/pages/rubsignin/widgets/signin_form.dart
@@ -46,7 +46,7 @@ class SignInForm extends StatelessWidget {
             const SizedBox(height: 80),
             Text(
               localization.welcome,
-              style: themeData.textTheme.headline1!.copyWith(
+              style: themeData.textTheme.displayLarge!.copyWith(
                 fontSize: 50,
                 fontWeight: FontWeight.w500,
                 letterSpacing: 4,
@@ -55,7 +55,7 @@ class SignInForm extends StatelessWidget {
             const SizedBox(height: 20),
             Text(
               localization.login_prompt,
-              style: themeData.textTheme.headline1!.copyWith(
+              style: themeData.textTheme.displayLarge!.copyWith(
                 fontSize: 14,
                 fontWeight: FontWeight.w500,
                 letterSpacing: 4,

--- a/lib/utils/pages/mensa_utils.dart
+++ b/lib/utils/pages/mensa_utils.dart
@@ -8,7 +8,7 @@ class MensaUtils extends Utils {
   }
 
   bool isNumeric(String s) {
-    if (s == null) {
+    if (s.isEmpty) {
       return false;
     }
     return double.tryParse(s) != null;


### PR DESCRIPTION
I think we need to make some changes there is some really bad code that got pushed with https://github.com/astarub/campus_app/commit/86880e250da715f4d8dee0054683624594d38988

The check for null will always be false as long as the function is called. String check would need to be against empty in this case. But whats even more awful is the usage of this function. As far as i can see the function is called by the mensa parser to check if something is a number by trying to cast it to a double????? 
Why in the world would one do that? Wouldnt it be much cleaner to run something like regular expressions on the string? And even then i have a hard time treating the result as something else then a string. This seems pretty hacky. 

Long term it should either be rewritten with something better like regular expressions or be done i a clean way with the backend so the data types are known beforehand. 