### PR TITLE
Recreate settings file if it's corrupted

### DIFF
--- a/lib/env/env.dart
+++ b/lib/env/env.dart
@@ -11,11 +11,11 @@ part 'env.g.dart';
 abstract class Env {
   // Can be called to access the obfuscated mensa API key
   @EnviedField(varName: 'MENSA_API_KEY', obfuscate: true)
-  static final mensaApiKey = _Env.mensaApiKey;
+  static final String mensaApiKey = _Env.mensaApiKey;
 
   @EnviedField(varName: 'FIREBASE_ANDROID_API_KEY', obfuscate: true)
-  static final firebaseAndroidApiKey = _Env.firebaseAndroidApiKey;
+  static final String firebaseAndroidApiKey = _Env.firebaseAndroidApiKey;
 
   @EnviedField(varName: 'FIREBASE_IOS_API_KEY', obfuscate: true)
-  static final firebaseIosApiKey = _Env.firebaseIosApiKey;
+  static final String firebaseIosApiKey = _Env.firebaseIosApiKey;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -95,8 +95,23 @@ class _CampusAppState extends State<CampusApp> with WidgetsBindingObserver {
           // Load settings and parse it
           settingsJsonFile.readAsString().then((String rawFileContent) {
             if (rawFileContent != '') {
-              final dynamic rawData = json.decode(rawFileContent);
-              loadedSettings = Settings.fromJson(rawData);
+              try {
+                final dynamic rawData = json.decode(rawFileContent);
+                loadedSettings = Settings.fromJson(rawData);
+              } catch (e) {
+                debugPrint('Settings file corrupted. Creating a new settings file.');
+
+                settingsJsonFile.deleteSync();
+                settingsJsonFile.create();
+
+                loadedSettings = Settings(
+                  feedFilter: ['RUB'],
+                  mensaPreferences: [],
+                  mensaAllergenes: [],
+                );
+
+                settingsJsonFile.writeAsString(json.encode(loadedSettings!.toJson()));
+              }
               loadedSettings = loadedSettings!.copyWith(newsExplore: false); // Default Feed on every start
 
               debugPrint('Settings loaded.');


### PR DESCRIPTION
This PR implements a validation to check if the settings file is corrupted, which causes the app to stall and become unusable. If that happens, the settings file should be re-created.