### PR TITLE
Hotfix for 2.1.0 Update

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -179,6 +179,7 @@ class CampusAppState extends State<CampusApp> with WidgetsBindingObserver {
         settingsJsonFile.create();
         final Settings initialSettings = Settings(
           mensaAllergenes: [],
+          mensaPreferences: [],
           mensaRestaurantConfig: mensaUtils.restaurantConfig,
         );
         settingsJsonFile.writeAsString(json.encode(initialSettings.toJson()));

--- a/lib/pages/wallet/mensa_balance_page.dart
+++ b/lib/pages/wallet/mensa_balance_page.dart
@@ -183,8 +183,8 @@ class _MensaBalancePageState extends State<MensaBalancePage> with TickerProvider
     try {
       FlutterNfcKit.finish();
       // ignore: empty_catches
-    } on PlatformException {
-      debugPrint('yes');
+    } catch (e) {
+      debugPrint('Exception while finishing NFC adapter.');
     }
   }
 

--- a/lib/pages/wallet/widgets/wallet.dart
+++ b/lib/pages/wallet/widgets/wallet.dart
@@ -133,7 +133,13 @@ class _BogestraTicketState extends State<BogestraTicket> with AutomaticKeepAlive
   }
 
   Future<void> addTicket() async {
-    final FilePickerResult? result = await FilePicker.platform.pickFiles();
+    FilePickerResult? result;
+
+    try {
+      result = await FilePicker.platform.pickFiles();
+    } catch (e) {
+      debugPrint('Access files permission not granted.');
+    }
 
     if (result != null) {
       final File file = File(result.files.single.path!);


### PR DESCRIPTION
This PR fixes the issue, where new users can't select Mensa prefrences on first first start up.
Although it works the second time they boot the app, this behaviour is still unsatisfying. 