### PR TITLE
Hotfix release 3.0.1

### DIFF
--- a/lib/pages/feed/widgets/feed_item.dart
+++ b/lib/pages/feed/widgets/feed_item.dart
@@ -132,7 +132,7 @@ class FeedItemState extends State<FeedItem> with AutomaticKeepAliveClientMixin {
     }
 
     void openDetailsPage() {
-      if (widget.webViewUrl != null) {
+      if (widget.webViewUrl != null && widget.webViewUrl!.isNotEmpty) {
         Navigator.push(
           context,
           MaterialPageRoute(builder: (context) => InAppWebViewPage(url: widget.webViewUrl!)),


### PR DESCRIPTION
Due to an incorrect check of types and values in the feed_item.dart file, a web view is opened although some feed items have an empty web view url. 