### PR TITLE
Re-render semester ticket on update

### DIFF
--- a/lib/pages/wallet/widgets/wallet.dart
+++ b/lib/pages/wallet/widgets/wallet.dart
@@ -88,6 +88,24 @@ class _BogestraTicketState extends State<BogestraTicket> with AutomaticKeepAlive
     );
   }
 
+  Future<void> loadAndRenderTicket() async {
+    // Pre-render ticket
+    await renderTicket();
+
+    final String? oldAztecCode = await ticketRepository.getAztecCode();
+
+    await ticketRepository.loadTicket().catchError((error) {
+      debugPrint('Wallet widget: $error');
+    });
+
+    final String? newAztecCode = await ticketRepository.getAztecCode();
+
+    // Compare aztec code from before re-loading the ticket with the new one
+    if (oldAztecCode != newAztecCode) {
+      await renderTicket();
+    }
+  }
+
   @override
   bool get wantKeepAlive => true;
 
@@ -95,10 +113,7 @@ class _BogestraTicketState extends State<BogestraTicket> with AutomaticKeepAlive
   void initState() {
     super.initState();
 
-    ticketRepository.loadTicket().catchError((error) {
-      debugPrint('Wallet widget: $error');
-    });
-    renderTicket();
+    loadAndRenderTicket();
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1488,30 +1488,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  uni_links:
-    dependency: "direct main"
-    description:
-      name: uni_links
-      sha256: "051098acfc9e26a9fde03b487bef5d3d228ca8f67693480c6f33fd4fbb8e2b6e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.1"
-  uni_links_platform_interface:
-    dependency: transitive
-    description:
-      name: uni_links_platform_interface
-      sha256: "929cf1a71b59e3b7c2d8a2605a9cf7e0b125b13bc858e55083d88c62722d4507"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
-  uni_links_web:
-    dependency: transitive
-    description:
-      name: uni_links_web
-      sha256: "7539db908e25f67de2438e33cc1020b30ab94e66720b5677ba6763b25f6394df"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
   universal_io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,6 @@ dependencies:
   firebase_messaging: ^15.1.4
   flutter_local_notifications: ^18.0.1
   share_plus: ^10.1.2
-  uni_links: ^0.5.1
   flutter_onboarding:
     git:
       url: https://github.com/C4s4r/flutter_onboarding


### PR DESCRIPTION
This PR fixes #179 where the semester ticket was not re-rendered when the aztec code changed. 
By comparing the saved aztec code with the fetched one, the issue should be resolved. 

Additionally the `uni_links` package is removed.