### PR TITLE
Add null checks to calendar entities

### DIFF
--- a/lib/pages/calendar/entities/event_entity.dart
+++ b/lib/pages/calendar/entities/event_entity.dart
@@ -148,8 +148,8 @@ class Event {
       id: json['id'],
       url: json['url'],
       title: json['title'],
-      description: json['description'],
-      slug: json['slug'],
+      description: json['description'] ?? '',
+      slug: json['slug'] ?? '',
       hasImage: hasImage,
       imageUrl: hasImage ? (json['image'] as Map<String, dynamic>)['url'] : null,
       startDate: DateFormat('yyyy-MM-dd HH:mm:ss Z', 'de_DE').parse(
@@ -158,13 +158,13 @@ class Event {
       endDate: DateFormat('yyyy-MM-dd HH:mm:ss Z', 'de_DE').parse(
         "${json['end_date']} ${json['timezone']}",
       ),
-      allDay: json['all_day'],
+      allDay: json['all_day'] ?? false,
       cost: cost,
-      website: json['website'],
+      website: json['website'] ?? '',
       categories: categories,
       venue: venue,
       organizers: organizers,
-      author: json['author'],
+      author: json['author'] ?? '',
       pinned: json['pinned'] ?? false,
     );
   }

--- a/lib/pages/calendar/entities/organizer_entity.dart
+++ b/lib/pages/calendar/entities/organizer_entity.dart
@@ -49,10 +49,10 @@ class Organizer {
     final email = json.containsKey('email') ? json['email'] : null;
 
     return Organizer(
-      id: json['id'],
-      name: json['organizer'],
-      url: json['url'],
-      slug: json['slug'],
+      id: json['id'] ?? -1,
+      name: json['organizer'] ?? '',
+      url: json['url'] ?? '',
+      slug: json['slug'] ?? '',
       phone: phone,
       website: website,
       email: email,

--- a/lib/pages/calendar/entities/venue_entity.dart
+++ b/lib/pages/calendar/entities/venue_entity.dart
@@ -68,10 +68,10 @@ class Venue {
     final phone = json.containsKey('phone') ? json['phone'] : null;
 
     return Venue(
-      id: json['id'],
-      name: json['venue'],
-      url: json['url'],
-      slug: json['slug'],
+      id: json['id'] ?? '',
+      name: json['venue'] ?? '',
+      url: json['url'] ?? '',
+      slug: json['slug'] ?? '',
       address: address,
       city: city,
       country: country,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: campus_app
 description: Simplifie, improve and facilitate everyday students life.
 publish_to: 'none'
-version: 2.3.3
+version: 2.3.4
 
 environment:
   sdk: ">=3.5.0 <4.0.0"


### PR DESCRIPTION
There was an issue with null values being passed to `venue_entity.dart`.
With this PR this should now be fixed.