### PR TITLE
Minior Fixes

### DIFF
--- a/lib/pages/feed/news/news_entity.dart
+++ b/lib/pages/feed/news/news_entity.dart
@@ -118,8 +118,8 @@ class NewsEntity {
     final String formattedContent = content
         .replaceAll(RegExp('(?:[\t ]*(?:\r?\n|\r))+'), '')
         .replaceAll(RegExp(' {2,}'), ' ')
-        // Remove first figure if post starts with a figure
-        .replaceAll(RegExp('^<figure[^>]*>.*?</figure>', dotAll: true), '')
+        // Remove wordpress featured images from content
+        .replaceAll(RegExp('<figure class="wp-block-post-featured-image">.*?</figure>', dotAll: true), '')
         .replaceAll('\n', '');
     final List<String> descWords = formattedContent.split(' ');
     final List<String> descriptionList = [];

--- a/lib/pages/feed/news/news_entity.dart
+++ b/lib/pages/feed/news/news_entity.dart
@@ -73,7 +73,7 @@ class NewsEntity {
 
   /// Returns a NewsEntity based on a single XML element given by the web server
   factory NewsEntity.fromXML(XmlElement xml, Map<String, dynamic> imageData) {
-    final content = xml.getElement('content')!.innerText;
+    final content = xml.getElement('content:encoded')!.innerText;
     final title = xml.getElement('title')!.innerText;
     final url = xml.getElement('link')!.innerText;
     final description = xml.getElement('description')!.innerText;

--- a/lib/pages/feed/news/news_repository.dart
+++ b/lib/pages/feed/news/news_repository.dart
@@ -25,7 +25,7 @@ class NewsRepository {
 
       for (final e in astaFeed) {
         final entity = NewsEntity.fromJSON(json: e, copyright: ['© AStA']);
-        final past = DateTime.now().subtract(const Duration(days: 21));
+        final past = DateTime.now().subtract(const Duration(days: 60));
 
         if (entity.pubDate.compareTo(past) > 0) {
           entities.add(entity);
@@ -34,7 +34,7 @@ class NewsRepository {
 
       for (final e in appFeed) {
         final entity = NewsEntity.fromJSON(json: e, copyright: ['© AStA']);
-        final past = DateTime.now().subtract(const Duration(days: 21));
+        final past = DateTime.now().subtract(const Duration(days: 60));
 
         if (entity.pubDate.compareTo(past) > 0) {
           entities.add(entity);

--- a/lib/pages/mensa/mensa_repository.dart
+++ b/lib/pages/mensa/mensa_repository.dart
@@ -1,17 +1,25 @@
 import 'dart:async';
 
-import 'package:dartz/dartz.dart';
-import 'package:intl/intl.dart';
-
 import 'package:campus_app/core/exceptions.dart';
 import 'package:campus_app/core/failures.dart';
 import 'package:campus_app/pages/mensa/dish_entity.dart';
 import 'package:campus_app/pages/mensa/mensa_datasource.dart';
+import 'package:dartz/dartz.dart';
+import 'package:intl/intl.dart';
 
 class MensaRepository {
   final MensaDataSource mensaDatasource;
 
   MensaRepository({required this.mensaDatasource});
+
+  /// Returns a list of [DishEntity] widgets or a failure
+  Either<Failure, List<DishEntity>> getCachedDishes(int restaurant) {
+    try {
+      return Right(mensaDatasource.readDishEntitiesFromCache(restaurant));
+    } catch (e) {
+      return Left(CachFailure());
+    }
+  }
 
   /// Returns a list of [DishEntity] widgets or a failure.
   /// Reataurant is 1 (Mensa) by default. Theire are the following possible values:
@@ -36,40 +44,40 @@ class MensaRepository {
         // Correct DateFormat is e.g. "Mo., 10.10." instead of "Mo, 10.10."
         final datetime = DateFormat('E, y.d.M.', 'de_DE').parse(day.replaceRange(2, 4, '., ${firstDayOfWeek.year}.'));
 
-        late int date;
+        int date = -1;
         switch (datetime.weekday) {
           case 1: // Monday
             if (datetime.compareTo(lastDayOfWeek) > 0) {
               date = 5;
-            } else {
+            } else if (datetime.compareTo(firstDayOfWeek) >= 0) {
               date = 0;
             }
             break;
           case 2: // Tuesday
             if (datetime.compareTo(lastDayOfWeek) > 0) {
               date = 6;
-            } else {
+            } else if (datetime.compareTo(firstDayOfWeek) > 0) {
               date = 1;
             }
             break;
           case 3: // Wednesday
             if (datetime.compareTo(lastDayOfWeek) > 0) {
               date = 7;
-            } else {
+            } else if (datetime.compareTo(firstDayOfWeek) > 0) {
               date = 2;
             }
             break;
           case 4: // Thursday
             if (datetime.compareTo(lastDayOfWeek) > 0) {
               date = 8;
-            } else {
+            } else if (datetime.compareTo(firstDayOfWeek) > 0) {
               date = 3;
             }
             break;
           default: // Friday, Saturday or Sunday
             if (datetime.compareTo(lastDayOfWeek) > 0) {
               date = 9;
-            } else {
+            } else if (datetime.compareTo(firstDayOfWeek) > 0) {
               date = 4;
             }
             break;
@@ -127,15 +135,6 @@ class MensaRepository {
         default:
           return Left(GeneralFailure());
       }
-    }
-  }
-
-  /// Returns a list of [DishEntity] widgets or a failure
-  Either<Failure, List<DishEntity>> getCachedDishes(int restaurant) {
-    try {
-      return Right(mensaDatasource.readDishEntitiesFromCache(restaurant));
-    } catch (e) {
-      return Left(CachFailure());
     }
   }
 }


### PR DESCRIPTION
- RUB News article caused a TypeError (null check used) because of changed XML format. 
- Some feed articles were not displayed correctly because WordPress also rendered the feature image in the content.
- Posts older than 21 days but still relevant were not displayed. Now posts from the last 60 days are displayed.
- Minor hotfixes were applied to the cafeteria, as some dishes were displayed twice.